### PR TITLE
Fix carriable persisting on death

### DIFF
--- a/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
+++ b/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
@@ -3,9 +3,14 @@ package me.steven.carrier.mixin;
 import me.steven.carrier.Carrier;
 import me.steven.carrier.api.CarrierComponent;
 import me.steven.carrier.api.CarryingData;
+import me.steven.carrier.api.Carriable;
+import me.steven.carrier.api.CarriableRegistry;
+import me.steven.carrier.api.CarriablePlacementContext;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -35,6 +40,19 @@ public abstract class MixinPlayerEntity extends LivingEntity  {
         CarryingData carrying = carrier.getCarryingData();
         if (carrying != null) {
             cir.setReturnValue(false);
+        }
+    }
+    @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V"))
+    private void c(CallbackInfo ci) {
+        CarrierComponent carrier = Carrier.HOLDER.get(this);
+        CarryingData carrying = carrier.getCarryingData();
+        if (carrying != null) {
+            Carriable<?> carriable = CarriableRegistry.INSTANCE.get(carrying.getType());
+            BlockPos pos = this.getBlockPos();
+            if (!world.isClient && carriable != null && world.getBlockState(pos).getMaterial().isReplaceable()) {
+                carriable.tryPlace(carrier, world, new CarriablePlacementContext(carrier, carriable, pos, Direction.DOWN, this.getHorizontalFacing()));
+            }
+            carrier.setCarryingData(null);
         }
     }
 }

--- a/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
+++ b/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
@@ -50,9 +50,11 @@ public abstract class MixinPlayerEntity extends LivingEntity  {
             Carriable<?> carriable = CarriableRegistry.INSTANCE.get(carrying.getType());
             BlockPos pos = this.getBlockPos();
             if (!world.isClient && carriable != null && world.getBlockState(pos).getMaterial().isReplaceable()) {
-                carriable.tryPlace(carrier, world, new CarriablePlacementContext(carrier, carriable, pos, Direction.DOWN, this.getHorizontalFacing()));
+                if (carriable.tryPlace(carrier, world, new CarriablePlacementContext(carrier, carriable, pos, Direction.DOWN, this.getHorizontalFacing())).isAccepted())
+                    carrier.setCarryingData(null);
+            }else {
+                carrier.setCarryingData(null);
             }
-            carrier.setCarryingData(null);
         }
     }
 }

--- a/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
+++ b/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
@@ -49,10 +49,8 @@ public abstract class MixinPlayerEntity extends LivingEntity  {
         if (carrying != null) {
             Carriable<?> carriable = CarriableRegistry.INSTANCE.get(carrying.getType());
             BlockPos pos = this.getBlockPos();
-            if (!world.isClient && carriable != null && world.getBlockState(pos).getMaterial().isReplaceable()) {
-                if (carriable.tryPlace(carrier, world, new CarriablePlacementContext(carrier, carriable, pos, Direction.DOWN, this.getHorizontalFacing())).isAccepted())
-                    carrier.setCarryingData(null);
-            }else {
+            if (!world.isClient && carriable != null && world.getBlockState(pos).getMaterial().isReplaceable() &&
+                    carriable.tryPlace(carrier, world, new CarriablePlacementContext(carrier, carriable, pos, Direction.DOWN, this.getHorizontalFacing())).isAccepted()) {
                 carrier.setCarryingData(null);
             }
         }

--- a/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
+++ b/src/main/java/me/steven/carrier/mixin/MixinPlayerEntity.java
@@ -42,7 +42,7 @@ public abstract class MixinPlayerEntity extends LivingEntity  {
             cir.setReturnValue(false);
         }
     }
-    @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V"))
+    @Inject(method = "dropInventory", at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/PlayerInventory;dropAll()V", shift = At.Shift.AFTER))
     private void c(CallbackInfo ci) {
         CarrierComponent carrier = Carrier.HOLDER.get(this);
         CarryingData carrying = carrier.getCarryingData();


### PR DESCRIPTION
when a player had a carriable and died they would keep it
this fixes that (unless keepInventory is on)