### PR TITLE
check for null player on block use

### DIFF
--- a/src/main/java/me/steven/carrier/mixin/MixinAbstractBlock.java
+++ b/src/main/java/me/steven/carrier/mixin/MixinAbstractBlock.java
@@ -16,6 +16,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public class MixinAbstractBlock {
     @Inject(method = "onUse", at = @At("INVOKE"), cancellable = true)
     private void carrier_interactBlock(World world, PlayerEntity player, Hand hand, BlockHitResult hit, CallbackInfoReturnable<ActionResult> cir) {
+        if(player == null) return;
         ActionResult actionResult = HolderInteractCallback.INSTANCE.interact(player, world, hand, hit);
         if (actionResult.isAccepted()) cir.setReturnValue(actionResult);
     }


### PR DESCRIPTION
if you use carpet-extra with dispenser toggling things you will get a crash because carrier expects the player to not be null on block interaction, this should fix it