### PR TITLE
Add "carrier:blocks/blacklist" tag

### DIFF
--- a/src/main/java/me/steven/carrier/Carrier.java
+++ b/src/main/java/me/steven/carrier/Carrier.java
@@ -19,6 +19,7 @@ import net.fabricmc.fabric.api.event.lifecycle.v1.ServerTickEvents;
 import net.fabricmc.fabric.api.event.registry.RegistryEntryAddedCallback;
 import net.fabricmc.fabric.api.item.v1.FabricItemSettings;
 import net.fabricmc.fabric.api.network.ServerSidePacketRegistry;
+import net.fabricmc.fabric.api.tag.TagFactory;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.block.AbstractBannerBlock;
 import net.minecraft.block.AbstractChestBlock;
@@ -31,6 +32,7 @@ import net.minecraft.nbt.NbtCompound;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
+import net.minecraft.tag.Tag;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.LiteralText;
 import net.minecraft.text.Style;
@@ -56,6 +58,8 @@ public class Carrier implements ModInitializer, EntityComponentInitializer {
     public static final Item ITEM_GLOVE = new GloveItem(new FabricItemSettings().group(ItemGroup.TOOLS).maxCount(1));
 
     public static final Identifier SET_CAN_CARRY_PACKET = new Identifier(MOD_ID, "can_carry_packet");
+
+    public static final Tag<Block> BLACKLIST = TagFactory.BLOCK.create(new Identifier(MOD_ID, "blacklist"));
 
     @Override
     public void onInitialize() {
@@ -168,6 +172,8 @@ public class Carrier implements ModInitializer, EntityComponentInitializer {
     }
 
     public static boolean canCarry(Identifier id) {
+        if (Registry.BLOCK.getOrEmpty(id).stream().anyMatch(BLACKLIST::contains)) return false;
+
         if (CONFIG.getType() == Config.ListType.WHITELIST) return CONFIG.getList().stream().anyMatch((s) -> Pattern.compile(s).matcher(id.toString()).find());
         else return CONFIG.getList().stream().noneMatch((s) -> Pattern.compile(s).matcher(id.toString()).find());
     }


### PR DESCRIPTION
This tag is used to completely blacklist a block from being picked up by Carrier, mainly used by me in Conjuring to fix compatibility